### PR TITLE
Add possibility to specify options for guzzle

### DIFF
--- a/lib/Nekland/BaseApi/Http/AbstractHttpClient.php
+++ b/lib/Nekland/BaseApi/Http/AbstractHttpClient.php
@@ -75,6 +75,7 @@ abstract class AbstractHttpClient
     /**
      * @param string $option
      * @param mixed  $default
+     * @return mixed
      */
     public function getOption($option, $default = null)
     {

--- a/lib/Nekland/BaseApi/Http/ClientAdapter/GuzzleAdapter.php
+++ b/lib/Nekland/BaseApi/Http/ClientAdapter/GuzzleAdapter.php
@@ -26,7 +26,9 @@ class GuzzleAdapter extends AbstractHttpClient
     public function __construct(EventDispatcher $dispatcher, array $options = [], Client $client = null)
     {
         parent::__construct($dispatcher, $options);
-        $this->guzzle = $client ?: new Client();
+
+        $guzzleOptions = isset($options['guzzle']) ? $options['guzzle'] : [];
+        $this->guzzle = $client ?: new Client($guzzleOptions);
     }
 
     protected function execute(Request $request)


### PR DESCRIPTION
Fixed #9 

This avoid the need to extends the default adapter to give options to guzzle.
